### PR TITLE
Add Docker setup for local builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+_site
+website/_site
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:3.2
+
+# Install packages needed for Jekyll and building native extensions
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+# Pre-install bundler to match the Gemfile.lock version
+RUN gem install bundler -v 2.6.8
+
+# Copy gem files first for caching
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+# Copy the rest of the project
+COPY . .
+
+# Default command builds the site
+CMD ["bundle", "exec", "jekyll", "build", "--source=website", "--destination=_site"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Lotus Oak Foundation
+
+This repository hosts the Jekyll source for the Lotus Oak Foundation website. A
+Docker setup is provided for building the site locally without installing Ruby o
+r Jekyll on your machine.
+
+## Building with Docker
+
+1. Build the Docker image:
+   ```bash
+   docker build -t lotusoak-site .
+   ```
+2. Run the image to build and serve the site:
+   ```bash
+   docker run --rm -p 4000:4000 lotusoak-site bundle exec jekyll serve \
+     --source=website --destination=_site --host=0.0.0.0
+   ```
+   The site will be available at [http://localhost:4000](http://localhost:4000).
+
+The default container command simply builds the site, which is useful for CI p
+ipelines.


### PR DESCRIPTION
## Summary
- add Dockerfile to build Jekyll site in a container
- add `.dockerignore` to avoid sending built files to Docker build context
- document Docker workflow in new `README.md`

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_b_683e356103108327888fd62897820e69